### PR TITLE
update ips_list with ohw pulp_soc

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,9 +19,9 @@
 #
 
 pulp_soc:
-  commit: v2.0.1
+  commit: master
   server: https://github.com
-  group:  pulp-platform
+  group:  openhwgroup
 
 tbtools:
   commit: v0.1


### PR DESCRIPTION
At the moment the MCU points to the pulp_soc master but this will be in the next commits when the branch of CV32E40P of pulp_soc will be created