### PR TITLE
fix typo in fpga docs

### DIFF
--- a/fpga/README.md
+++ b/fpga/README.md
@@ -140,7 +140,7 @@ tc_clk_gating core_clock_gate_i
 4. Replace source files that instantiate cv32e40p and set hartid=0:
 ```
 $ cp $COREVMCU/fpga/cv32e40p_modified_files/fc_subsystem.sv $COREVMCU/ips/pulp_soc/rtl/fc/fc_subsystem.sv
-$ cp $COREVMCU/fpga/cv32e40p_modified_files/pulp_socsv $COREVMCU/ips/pulp_soc/rtl/pulp_soc/pulp_soc.sv
+$ cp $COREVMCU/fpga/cv32e40p_modified_files/pulp_soc.sv $COREVMCU/ips/pulp_soc/rtl/pulp_soc/pulp_soc.sv
 ```
   * Note: Pulpissimo's default hartid is set to 992; however, for compatibility with the RISC-V Privileged Architecture and operating systems such as FreeRTOS, CORE-V-MCU will use hartid=0.
 


### PR DESCRIPTION
Hi!

I was going over the documentations and I noticed there is a typo in the FPGA README.md.

Hope this helps! :smile:  