### PR TITLE
Fix documentation of the documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,20 @@
 # Documentation
 
-To locally build the documentation run:
+## Prerequisites
+
+You need to install the following Sphinx extensions (in addition to the
+requirements in `../python-requirements.txt`).
 
 ```
-make html
+pip3 install --user recommonmark
+pip3 install --user sphinx_markdown_tables
+pip3 install --user sphinx_rtd_theme
+```
+
+## Build the documentation
+
+To locally build the documentation as HTML run:
+
+```
+make
 ```


### PR DESCRIPTION
	The instructions to build the documentation are wrong. They also
	have pre-requisites, beyond those generically specified in the
	parent directory.

Files changed:

	* docs/README.md: Specifiy prerequisites and correct the local
	build instructions.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>