### PR TITLE
Generate the Verilator model as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,27 @@ The resulting documents are accessed using file ./docs/_build/html/index.html
 $ make docs
 ```
 The resulting header files are located in ./sw
+
+## Experimental fuseSoC Support
+
+Run Verilator lint target:
+
+```
+fusesoc --cores-root . run --target=lint --setup --build openhwgroup.org:systems:core-v-mcu
+```
+
+To build Verilator as a library which can be linked into other tools (such as
+the debug server):
+
+```
+fusesoc --cores-root . run --target=model-lib --setup --build openhwgroup.org:systems:core-v-mcu
+```
+
+The library will be in the `obj_dir` subdirectory of the work root.
+
+Once can sanity check the top-level using QuestaSim:
+
+```
+fusesoc --cores-root . run --target=sim --setup --build --run openhwgroup.org:systems:core-v-mcu
+```
+

--- a/rtl/core-v-mcu/core-v-mcu.core
+++ b/rtl/core-v-mcu/core-v-mcu.core
@@ -84,11 +84,28 @@ filesets:
     - components/freq_meter.sv
     file_type: systemVerilogSource
 
+  # Scripts for hooks
+  pre_build_scripts:
+    files:
+    - scripts/vedit.sh
+    file_type: user
+
+# A script to modify Verilator pre-build to generate a library, not an
+# executable.
+scripts:
+  pre_build_scripts:
+    cmd:
+    - sh
+    - ../src/openhwgroup.org_systems_core-v-mcu_0/scripts/vedit.sh
+    - openhwgroup.org_systems_core-v-mcu_0.vc
+
 targets:
   default: &default_target
     filesets:
     - files_rtl_generic
     - target_sim? (rtl-behavioral)
+    - target_model-lib? (rtl-behavioral)
+    - target_model-lib? (pre_build_scripts)
     - target_lint? (rtl-behavioral)
     toplevel: [core_v_mcu]
 
@@ -100,6 +117,20 @@ targets:
         vlog_options:
         - -override_timescale 1ns/1ps
 
+
+  # A target for a Verilator model as a library.
+  model-lib:
+    <<: *default_target
+    default_tool: verilator
+    toplevel: [core_v_mcu]
+    hooks:
+      pre_build: [pre_build_scripts]
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+        - -Wno-fatal
+        - --trace
 
   lint:
     <<: *default_target

--- a/rtl/core-v-mcu/scripts/vedit.sh
+++ b/rtl/core-v-mcu/scripts/vedit.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# A script to clean up FuseSoC verilator scripts
+#
+# Copyright (C) 2021 Open Hardware Group
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# FuseSoC's Verilator target really believes it is creating an executable, and
+# also generates all its code in the same directory, which clutters up the
+# space. This pre-build hook edits the Verilator argument file, to cause it to
+# generate a library in the default `obj_dir` subdirectory.
+#
+# We also need to modify the generated Makefile to build the library in the
+# `obj_dir` subdirectory.
+#
+# The name of the Verilator argument file is passed as the sole argument.
+
+# Change the Veriator options to build a library in obj_dir
+mv $1 $1.orig
+sed < $1.orig > $1 -e '/--Mdir/d' -e '/--exe/d'
+
+# Edit the Makefile to use obj_dir
+mv Makefile Makefile.orig
+sed < Makefile.orig > Makefile \
+    -e 's/\(..MAKE....MAKE_OPTIONS.\)\(.*$\)/\1 -C obj_dir \2/'

--- a/rtl/vendor/openhwgroup_cv32e40p.core
+++ b/rtl/vendor/openhwgroup_cv32e40p.core
@@ -71,5 +71,6 @@ targets:
     - target_sim? (latch_regfile)
     - target_sim? (files_sim)
     - target_lint? (files_sim)
+    - target_model-lib? (files_sim)
     - tool_vivado? (ff_regfile)
     - tool_verilator? (ff_regfile)

--- a/rtl/vendor/openhwgroup_cv32e40p_tracing.core
+++ b/rtl/vendor/openhwgroup_cv32e40p_tracing.core
@@ -4,7 +4,7 @@ CAPI=2:
 # Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
-name: "openhwgroup.org:ip:cv32e40p"
+name: "openhwgroup.org:ip:cv32e40p_tracing"
 description: "OpenHW Group RISC-V Core CV32E40P with tracing enabled."
 
 filesets:
@@ -81,5 +81,6 @@ targets:
     - target_sim? (latch_regfile)
     - target_sim? (files_tracer)
     - target_lint? (files_sim)
+    - target_model-lib? (files_sim)
     - tool_vivado? (ff_regfile)
     - tool_verilator? (ff_regfile)

--- a/rtl/vendor/pulp_plaform_tech_cells_generic.core
+++ b/rtl/vendor/pulp_plaform_tech_cells_generic.core
@@ -50,4 +50,4 @@ targets:
     - rtl
     - target_sim? (rtl_sim)
     - target_lint? (rtl_sim)
-
+    - target_model-lib? (rtl_sim)


### PR DESCRIPTION
	This modifies the cores, to give a `model-lib` target which will
	create a Verilator model as a library.  This can then be used by
	other projects, which will link in the Verilator model as a
	library.

	The first projects which will use this are a debug server to drive
	the Verilator model and a tool to execute binaries to completion.

Files changed:

	* README.md: Describe generating the Verilator library.
	* rtl/core-v-mcu/core-v-mcu.core: Add model-lib target, which in
	turn needs a pre-build hook and associated script.
	* rtl/core-v-mcu/scripts/vedit.sh: Created.
	* rtl/vendor/openhwgroup_cv32e40p.core: Add files_sim fileset to
	the default target for the model-lib target.
	* rtl/vendor/openhwgroup_cv32e40p_tracing.core: Likewise.
	* rtl/vendor/pulp_plaform_tech_cells_generic.core: Likewise.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>