### PR TITLE
Jpb verilator wrapper

### DIFF
--- a/rtl/core-v-mcu/core-v-mcu.core
+++ b/rtl/core-v-mcu/core-v-mcu.core
@@ -99,6 +99,12 @@ filesets:
     - verilator.waiver
     file_type: vlt
 
+  # Verilator wrapper
+  verilator_wrapper:
+    files:
+    - top/core_v_mcu_wrapper.sv
+    file_type: systemVerilogSource
+
 # A script to modify Verilator pre-build to generate a library, not an
 # executable.
 scripts:
@@ -115,9 +121,9 @@ targets:
     - target_sim? (rtl-behavioral)
     - target_model-lib? (rtl-behavioral)
     - target_model-lib? (pre_build_scripts)
+    - target_model-lib? (verilator_wrapper)
     - target_lint? (rtl-behavioral)
     - tool_verilator? (verilator-waiver)
-    toplevel: [core_v_mcu]
 
   sim:
     <<: *default_target
@@ -126,13 +132,15 @@ targets:
       modelsim:
         vlog_options:
         - -override_timescale 1ns/1ps
+    toplevel: [core_v_mcu]
 
-
-  # A target for a Verilator model as a library.
+  # A target for a Verilator model as a library.  Note that we do not disable
+  # UNOPTFLAT warnings, since these will affect performance, so we want to see
+  # them.
   model-lib:
     <<: *default_target
     default_tool: verilator
-    toplevel: [core_v_mcu]
+    toplevel: [core_v_mcu_wrapper]
     hooks:
       pre_build: [pre_build_scripts]
     tools:
@@ -140,7 +148,6 @@ targets:
         mode: cc
         verilator_options:
         - -Wno-fatal
-        - -Wno-UNOPTFLAT
         - --trace
 
   lint:

--- a/rtl/core-v-mcu/top/core_v_mcu.sv
+++ b/rtl/core-v-mcu/top/core_v_mcu.sv
@@ -279,6 +279,20 @@ module core_v_mcu #(
   logic                                      debug1;
   logic                                      debug0;
 
+`ifdef VERILATOR
+  logic [`N_IO-1:0] io_pos;
+
+  assign s_ref_clk = io[6];
+  assign s_rstn = (io[6] == 1) ? io[7] : io_pos[7];
+  assign s_jtag_tck = (io[6] == 1) ? io[8] : io_pos[8];
+  assign s_jtag_tdi = (io[6] == 1) ? io[9] : io_pos[9];
+  assign io[10] = s_jtag_tdo;
+  assign s_jtag_tms = (io[6] == 1) ? io[11] : io_pos[11];
+  assign s_jtag_trst = (io[6] == 1) ? io[12] : io_pos[12];
+  assign s_bootsel = (io[6] == 1) ? io[15] : io_pos[15];
+
+  always @(posedge io[6]) io_pos <= io;
+`else
   //
   // PAD FRAME
   //
@@ -302,6 +316,7 @@ module core_v_mcu #(
       // pad signals
       .io(io)  // pad wires
   );
+`endif
 
   //
   // SAFE DOMAIN

--- a/rtl/core-v-mcu/top/core_v_mcu_wrapper.sv
+++ b/rtl/core-v-mcu/top/core_v_mcu_wrapper.sv
@@ -1,0 +1,64 @@
+// Copyright 2018 Open Hardware Group
+//
+// SPDX-License-Identifier: SHL-2.1
+
+`include "pulp_soc_defines.sv"
+`include "pulp_peripheral_defines.svh"
+
+module core_v_mcu_wrapper #(
+) (
+    input ref_clk_i,
+    input rstn_i,
+
+    // JTAG TAP
+    input  tck_i,
+    input  tdi_i,
+    output tdo_o,
+    input  tms_i,
+    input  trst_i,
+
+    // Boot select
+    input bootsel_i,
+
+    // General I/O
+    output [`N_IO-9:0] io_o,
+    input  [`N_IO-9:0] io_i,
+    input  [`N_IO-9:0] io_oe
+);
+
+  wire [`N_IO-1:0] io;
+
+  assign io[6]  = ref_clk_i;
+  assign io[7]  = rstn_i;
+
+  assign io[8]  = tck_i;
+  assign io[9]  = tdi_i;
+  assign tdo_o  = io[10];
+  assign io[11] = tms_i;
+  assign io[12] = trst_i;
+
+  assign io[15] = bootsel_i;
+
+  genvar i;
+  generate
+    for (i = 0; i <= 5; i++) begin
+      assign io[i]   = (io_oe[i] == 1'b0) ? io_i[i] : 1'bz;
+      assign io_o[i] = (io_oe[i] == 1'b1) ? io[i] : 1'bz;
+    end
+
+    for (i = 13; i <= 14; i++) begin
+      assign io[i] = (io_oe[i-7] == 1'b0) ? io_i[i-7] : 1'bz;
+      assign io_o[i-7] = (io_oe[i-7] == 1'b1) ? io[i] : 1'bz;
+    end
+
+    for (i = 16; i <= `N_IO - 1; i++) begin
+      assign io[i] = (io_oe[i-8] == 1'b0) ? io_i[i-8] : 1'bz;
+      assign io_o[i-8] = (io_oe[i-8] == 1'b1) ? io[i] : 1'bz;
+    end
+  endgenerate
+
+
+  core_v_mcu i_core_v_mcu (.io(io));
+
+endmodule
+;  // core_v_mcu_wrapper

--- a/rtl/core-v-mcu/verilator.waiver
+++ b/rtl/core-v-mcu/verilator.waiver
@@ -4460,3 +4460,5 @@ lint_off -rule UNOPTFLAT -file "*../src/pulp-platform.org__common_cells_1.20.0/s
 lint_off -rule UNOPTFLAT -file "*../src/pulp-platform.org__common_cells_1.20.0/src/rr_arb_tree.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: 'core_v_mcu.i_soc_domain.i_soc_interconnect_wrap.i_soc_interconnect.i_interleaved_xbar.i_xbar.gen_outputs[2].gen_rr_arb_tree.i_rr_arb_tree.gen_arbiter.data_nodes'"
 lint_off -rule UNOPTFLAT -file "*../src/pulp-platform.org__common_cells_1.20.0/src/rr_arb_tree.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: 'core_v_mcu.i_soc_domain.i_soc_interconnect_wrap.i_soc_interconnect.i_interleaved_xbar.i_xbar.gen_outputs[3].gen_rr_arb_tree.i_rr_arb_tree.gen_arbiter.data_nodes'"
 lint_off -rule UNUSED -file "*../src/pulp-platform.org__fpu_div_sqrt_mvp_0/pulp_platform_fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv" -match "Signal is not used: 'Div_start_dly_SI'"
+// Only affects this one file, and only when building a real model.
+lint_off --rule BLKANDNBLK -file "*../src/pulp-platform.org__fpnew_0/pulp_platform_fpnew/src/fpnew_divsqrt_multi.sv"

--- a/rtl/core-v-mcu/verilator.waiver
+++ b/rtl/core-v-mcu/verilator.waiver
@@ -4462,3 +4462,9 @@ lint_off -rule UNOPTFLAT -file "*../src/pulp-platform.org__common_cells_1.20.0/s
 lint_off -rule UNUSED -file "*../src/pulp-platform.org__fpu_div_sqrt_mvp_0/pulp_platform_fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv" -match "Signal is not used: 'Div_start_dly_SI'"
 // Only affects this one file, and only when building a real model.
 lint_off --rule BLKANDNBLK -file "*../src/pulp-platform.org__fpnew_0/pulp_platform_fpnew/src/fpnew_divsqrt_multi.sv"
+// Rules for new Verilator top level wrapper
+lint_off --rule UNUSED -file "*../src/openhwgroup.org_systems_core-v-mcu_0/top/core_v_mcu.sv" -match "Signal is not used: 's_pad_cfg'"
+lint_off --rule UNUSED -file "*../src/openhwgroup.org_systems_core-v-mcu_0/top/core_v_mcu.sv" -match "Signal is not used: 's_io_out'"
+lint_off --rule UNUSED -file "*../src/openhwgroup.org_systems_core-v-mcu_0/top/core_v_mcu.sv" -match "Signal is not used: 's_io_oe'"
+lint_off --rule UNDRIVEN -file "*../src/openhwgroup.org_systems_core-v-mcu_0/top/core_v_mcu.sv" -match "Signal is not driven: 's_io_in'"
+lint_off --rule UNUSED -file "*../src/openhwgroup.org_systems_core-v-mcu_0/top/core_v_mcu.sv" -match "Bits of signal are not used: 'io_pos'[47:16,14:13,10,6:0]"


### PR DESCRIPTION
This cleans up the FuseSoc model-lib target, to give it a wrapper with just input and output ports and with an added waiver for BLKANDNBLK errors in one FPU file.
