### PR TITLE
Use modern Verilator time handling

### DIFF
--- a/rtl/core-v-mcu/core-v-mcu.core
+++ b/rtl/core-v-mcu/core-v-mcu.core
@@ -149,6 +149,7 @@ targets:
         verilator_options:
         - -Wno-fatal
         - --trace
+        - --CFLAGS -DVL_TIME_CONTEXT
 
   lint:
     <<: *default_target


### PR DESCRIPTION
	Historically Verilator required you to implement a global function
	sc_time_stamp for plain C++ models inorder to handle Verilog
	$time.  Since Verilator 4.200 this is no longer needed, but
	sometimes you need to be explicit about this to Verilator using a
	C pre-processor define.

Files changed:

	* rtl/core-v-mcu/core-v-mcu.core: Add option --CFLAGS
	-DVL_TIME_CONTEXT to avoid need for sc_time_stamp.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>