### PR TITLE
Restore Verilator model support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ rtl/tb/run-sim.log
 gmon.out
 modelsim.ini
 vivado.log
+model-lib.log
 lint.log
 nexys-emul.log
 sw/inc/

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ export PRIVATE_BANK_SIZE=8192
 help:
 			@echo "all:            generate build scripts, custom build files, doc and sw header files"
 			@echo "bitstream:      generate nexysA7-100T.bit file for emulation"
+			@echo "model-lib:      build a Verilator model library"
 			@echo "lint:           run Verilator lint check"
 			@echo "doc:            generate documentation"
 			@echo "sw:             generate C header files (in ./sw)"
@@ -40,6 +41,12 @@ all:	${IOSCRIPT_OUT} docs sw
 clean:
 				(cd docs; make clean)
 				(cd sw; make clean)
+
+.PHONY: model-lib
+model-lib:
+	fusesoc --cores-root . run --target=model-lib --setup \
+		--build openhwgroup.org:systems:core-v-mcu | tee model-lib.log
+
 
 lint:
 				fusesoc --cores-root . run --target=lint --setup --build openhwgroup.org:systems:core-v-mcu 2>&1 | tee lint.log

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ make with no argments will print a list of the current targets:
 $ make
 all:            generate build scripts, custom build files, doc and sw header files
 bitstream:      generate nexysA7-100T.bit file for emulation
+model-lib:      build a Verilator model library
 lint:           run Verilator lint check
-doc:            generate documentation
+docs:           generate documentation
 sw:             generate C header files (in ./sw)
 nexys-emul:     generate bitstream for Nexys-A7-100T emulation)
 buildsim:       build for Questa sim
@@ -113,6 +114,16 @@ fusesoc --cores-root . run --target=sim --setup --build --run openhwgroup.org:sy
 ## Contributing: Pre-commit checks
 
 If you are submitting a pull-request, it will be subject to pre-commit checks.  The two that most likely cause problems are the Verilator Lint check and the Verible format check.
+
+### Verilator model library
+
+The system will run
+```
+fusesoc --cores-root . run --target=model-lib --setup --build openhwgroup.org:systems:core-v-mcu
+```
+If your changes introduce any Verilator errors, you either need to fix these, or, if appropriate, add a rule to ignore them to `rtl/core-v-mcu/verilator.waiver`.
+
+This will create the Verilator library `Vcore_v_mcu_wrapper__ALL.a` in `build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator/obj_dir`.
 
 ### Verilator lint check
 

--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -137,17 +137,45 @@ filesets:
     - emulation/core-v-mcu-nexys/tcl/flatten.tcl
     file_type: tclSource
 
+  # Scripts for hooks
+  pre_build_scripts:
+    files:
+    - rtl/core-v-mcu/scripts/vedit.sh
+    file_type: user
+
+  # Waiver file, without which the model lib will not build.
+  verilator-waiver:
+    files:
+    - rtl/core-v-mcu/verilator.waiver
+    file_type: vlt
+
+  # Verilator wrapper
+  verilator_wrapper:
+    files:
+    - rtl/core-v-mcu/top/core_v_mcu_wrapper.sv
+    file_type: systemVerilogSource
+
 parameters:
   PULP_FPGA_EMUL:
     datatype: bool
     paramtype: vlogdefine
     default: true
 
+# A script to modify Verilator pre-build to generate a library, not an
+# executable.
+scripts:
+  pre_build_scripts:
+    cmd:
+    - sh
+    - ../src/openhwgroup.org_systems_core-v-mcu_0/rtl/core-v-mcu/scripts/vedit.sh
+    - openhwgroup.org_systems_core-v-mcu_0.vc
+
 targets:
   default: &default_target
     filesets:
     - files_rtl_generic
     - target_lint? (rtl-behavioral)
+    - target_model-lib? (rtl-behavioral)
     toplevel: [core_v_mcu]
 
   sim:
@@ -167,6 +195,27 @@ targets:
         vsim_options:
         - -voptargs="-O1"
 
+
+  # A target for a Verilator model as a library.  Note that we do not disable
+  # UNOPTFLAT warnings, since these will affect performance, so we want to see
+  # them.
+  model-lib:
+    <<: *default_target
+    default_tool: verilator
+    filesets_append:
+    - pre_build_scripts
+    - verilator_wrapper
+    - verilator-waiver
+    toplevel: [core_v_mcu_wrapper]
+    hooks:
+      pre_build: [pre_build_scripts]
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+        - -Wno-fatal
+        - --trace
+        - --CFLAGS -DVL_TIME_CONTEXT
 
   lint:
     <<: *default_target


### PR DESCRIPTION
	Commit 74abb26 removed support for creation of a Verilator
	library, used for the debug simulation target and standalone
	simulator.  This commit restores the target and documents it
	better in README.md, so people know it is there!

Files changed:

	* .gitignore: Ignore model-lib.log.
	* Makefile: Add model-lib as a phony target to invoke fusesoc.
	* README.md: Document the model-lib target.
	* core-v-mcu.core: Add model-lib as a target with associated
	filesets and script declarations.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>