### PR TITLE
Pdf vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ YML=$(shell find . -name '*.yml' -print)
 
 IOSCRIPT=rtl/includes/pulp_soc_defines.sv
 IOSCRIPT+=rtl/includes/pulp_peripheral_defines.svh
-IOSCRIPT+=rtl/includes/periph_bus_defines.sv
+IOSCRIPT+=rtl/includes/periph_bus_defines.svh
 IOSCRIPT+=pin-table.csv
 IOSCRIPT+=perdef.json
 #IOSCRIPT+=emulation/core-v-mcu-nexys/rtl/core_v_mcu_nexys.v
 IOSCRIPT+=emulation/core-v-mcu-nexys/constraints/Nexys-A7-100T-Master.xdc
 
 IOSCRIPT_OUT=rtl/core-v-mcu/top/pad_control.sv
-IOSCRIPT_OUT+=rtl/core-v-mcu/top/pad_frame.sv
+#IOSCRIPT_OUT+=rtl/core-v-mcu/top/pad_frame.sv
 IOSCRIPT_OUT+=rtl/includes/pulp_peripheral_defines.svh
-IOSCRIPT_OUT+=rtl/includes/periph_bus_defines.sv
+IOSCRIPT_OUT+=rtl/includes/periph_bus_defines.svh
 IOSCRIPT_OUT+=emulation/core-v-mcu-nexys/constraints/core-v-mcu-pin-assignment.xdc
 IOSCRIPT_OUT+=core-v-mcu-config.h
 
@@ -25,10 +25,8 @@ export INTERLEAVED_BANK_SIZE=28672
 export PRIVATE_BANK_SIZE=8192
 
 help:
-			@echo "all:            generate build scripts, custom build files, doc and sw header files"
-			@echo "src:            set up all generated source files"
-			@echo "bitstream:      generate nexysA7-100T.bit file for emulation"
-			@echo "model-lib:      build a Verilator model library"
+			@echo "all:            create generated src files, doc and sw header files"
+			@echo "src:            create generated src files"
 			@echo "lint:           run Verilator lint check"
 			@echo "doc:            generate documentation"
 			@echo "sw:             generate C header files (in ./sw)"
@@ -37,29 +35,35 @@ help:
 			@echo "sim:            run Questa sim"
 			@echo "clean:          remove generated files"
 
-all:		${IOSCRIPT_OUT} docs sw
+all:	${IOSCRIPT_OUT} docs sw
 
-src:		${IOSCRIPT_OUT}
+src:	${IOSCRIPT_OUT}
 
 clean:
-				(cd docs; make clean)
-				(cd sw; make clean)
-
-.PHONY: model-lib
-model-lib:
-	fusesoc --cores-root . run --target=model-lib --setup \
-		--build openhwgroup.org:systems:core-v-mcu | tee model-lib.log
-
+	(cd docs; make clean)
+	(cd sw; make clean)
 
 lint:
-				fusesoc --cores-root . run --target=lint --setup --build openhwgroup.org:systems:core-v-mcu 2>&1 | tee lint.log
+	fusesoc --cores-root . run --target=lint --setup --build openhwgroup.org:systems:core-v-mcu 2>&1 | tee lint.log
 
 .PHONY:sim
 sim:
-				(cd build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim; make run) 2>&1 | tee sim.log
+	ln -f  tb/mem_init_files/col0.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.CUTS[0].bank_i
+	ln -f  tb/mem_init_files/col1.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.CUTS[1].bank_i
+	ln -f  tb/mem_init_files/col2.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.CUTS[2].bank_i
+	ln -f  tb/mem_init_files/col3.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.CUTS[3].bank_i
+	ln -f  tb/mem_init_files/privateBank0.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.bank_sram_pri0_i
+	ln -f  tb/mem_init_files/privateBank1.mem build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.bank_sram_pri1_i
+	ln -f  tb/mem_init_files/cli_sim.txt build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/cli_sim.txt
+	ln -f  tb/wave.do build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim/wave.do
+	(cd build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim; make run-gui) 2>&1 | tee sim.log
+
 .PHONY:buildsim
 buildsim:
-				fusesoc --cores-root . run --no-export --target=sim --setup --build openhwgroup.org:systems:core-v-mcu 2>&1 | tee buildsim.log
+	(cd tb/uartdpi; cc -shared -Bsymbolic -fPIC -o uartdpi.so -lutil uartdpi.c)
+	fusesoc --cores-root . run --no-export --target=sim --setup --build openhwgroup.org:systems:core-v-mcu 2>&1 | tee buildsim.log
+
+
 
 nexys-emul:		${IOSCRIPT_OUT}
 				@echo "*************************************"
@@ -106,11 +110,10 @@ ${IOSCRIPT_OUT}:	${IOSCRIPT}
 				python3 util/ioscript.py\
 					--soc-defines rtl/includes/pulp_soc_defines.sv\
 					--peripheral-defines rtl/includes/pulp_peripheral_defines.svh\
-					--periph-bus-defines rtl/includes/periph_bus_defines.sv\
+					--periph-bus-defines rtl/includes/periph_bus_defines.svh\
 					--pin-table pin-table.csv\
 					--perdef-json perdef.json\
 					--pad-control rtl/core-v-mcu/top/pad_control.sv\
-					--pad-frame-sv rtl/core-v-mcu/top/pad_frame.sv\
 					--xilinx-core-v-mcu-sv emulation/core-v-mcu-nexys/rtl/core_v_mcu_nexys.v\
 					--input-xdc emulation/core-v-mcu-nexys/constraints/Nexys-A7-100T-Master.xdc\
 					--output-xdc emulation/core-v-mcu-nexys/constraints/core-v-mcu-pin-assignment.xdc
@@ -123,6 +126,9 @@ bitstream:	${SCRIPTS} ${IOSCRIPT_OUT}
 download0:
 	vivado -mode batch -source emulation/core-v-mcu-nexys/tcl/download_bitstream.tcl -tclargs\
              emulation/core_v_mcu_nexys.bit
+
 download:
 	vivado -mode batch -source emulation/core-v-mcu-nexys/tcl/download_bitstream1.tcl -tclargs\
              emulation/core_v_mcu_nexys.bit
+				(cd build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim; make run) 2>&1 | tee sim.log
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ $(info ${MD_FILES})
 
 INSTALL_DIR:="../../core-v-mcu-cli-test/doc"
 
-all:    doc
+all:    doc pdf
 
 clean:
 				rm -rf ${AUTO_MD_DIR}
@@ -39,7 +39,7 @@ ${AUTO_MD_DIR}/%.md : ${CSV_MIRROR_DIR}/%.csv
 			@mkdir -p ${AUTO_MD_DIR}
 			@python3 ../util/ioscript.py\
 				--soc-defines ../rtl/includes/pulp_soc_defines.sv\
-				--periph-bus-defines ../rtl/includes/periph_bus_defines.sv\
+				--periph-bus-defines ../rtl/includes/periph_bus_defines.svh\
 				--reg-def-csv $<\
 				--reg-def-md $@
 
@@ -47,7 +47,7 @@ ${AUTO_MD_DIR}/pin-table.md: ../pin-table.csv
 			@mkdir -p ${AUTO_MD_DIR}
 			@python3 ../util/ioscript.py\
 				--soc-defines ../rtl/includes/pulp_soc_defines.sv\
-				--periph-bus-defines ../rtl/includes/periph_bus_defines.sv\
+				--periph-bus-defines ../rtl/includes/periph_bus_defines.svh\
 				--peripheral-defines peripheral-defines.svh\
 				--perdef-json ../perdef.json\
 				--pin-table $<\

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,7 +39,7 @@ ${AUTO_MD_DIR}/%.md : ${CSV_MIRROR_DIR}/%.csv
 			@mkdir -p ${AUTO_MD_DIR}
 			@python3 ../util/ioscript.py\
 				--soc-defines ../rtl/includes/pulp_soc_defines.sv\
-				--periph-bus-defines ../rtl/includes/periph_bus_defines.svh\
+				--periph-bus-defines ../rtl/includes/periph_bus_defines.sv\
 				--reg-def-csv $<\
 				--reg-def-md $@
 
@@ -47,7 +47,7 @@ ${AUTO_MD_DIR}/pin-table.md: ../pin-table.csv
 			@mkdir -p ${AUTO_MD_DIR}
 			@python3 ../util/ioscript.py\
 				--soc-defines ../rtl/includes/pulp_soc_defines.sv\
-				--periph-bus-defines ../rtl/includes/periph_bus_defines.svh\
+				--periph-bus-defines ../rtl/includes/periph_bus_defines.sv\
 				--peripheral-defines peripheral-defines.svh\
 				--perdef-json ../perdef.json\
 				--pin-table $<\

--- a/rtl/vendor/pulp_platform_tech_cells_generic/src/deprecated/generic_memory.sv
+++ b/rtl/vendor/pulp_platform_tech_cells_generic/src/deprecated/generic_memory.sv
@@ -32,7 +32,16 @@ module generic_memory
    logic [DATA_WIDTH-1:0]                   MEM [NUM_WORDS-1:0];
    logic [DATA_WIDTH-1:0]                   M;
    genvar                         i,j;
-
+   string 			  s;
+   
+   initial begin
+      $display("%m");
+//      $sformatf(s,"%s",%m);
+      s = $psprintf("%m");
+      
+      $readmemh(s,MEM);
+   end
+   
    generate
       for (i=0; i<BE_WIDTH; i++)
         begin


### PR DESCRIPTION
a couple of CI issues. 
1) pandoc program missing - called from docs/Makefile in make all 
2) vendor file modification in rtl/vendor/pulp_platform_tech_cells_generic/src/deprecated/generic_memory.sv. added meminti capability
3) related to the above, the meminit uses $psprintf function to extract the instance name from the %m variable.  which lint flags as an unknown PLI call. We should be able use $sprintf to extract %m, but it doesn't recognize the %m name

Signed-off-by: Greg Martin <gmartin@quicklogic.com>