### PR TITLE
Update ID Code to OpenHW Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Extra note for building on ubuntu - Vivado tools from Xilinx may require a large
 The swap size can be increased by searching for "increase swapfile in ubuntu" and add your release.
 
 ## Building documentation
+
 ```
 $ make docs
 ```
@@ -72,14 +73,15 @@ CORE-V MCU are documented in the [PULP Platform Debug
 Unit](https://github.com/pulp-platform/riscv-dbg).
 
 ## Building C header files
+
 ```
 $ make sw
 ```
 The resulting header files are located in ./sw
 
 ## Running Modelsim/Questasim
-```
 
+```
 $ make buildsim sim
 ```
 The 'make buildsim' creates a work library in build/openhwgroup.org_systems_core-v-mcu_0/sim-modelsim, and then 'make sim' runs the simulation.

--- a/rtl/includes/pulp_soc_defines.sv
+++ b/rtl/includes/pulp_soc_defines.sv
@@ -32,7 +32,7 @@
 `define NB_L2_CHANNELS 4
 
 // JTAG
-`define DMI_JTAG_IDCODE 32'h249511C3
+`define DMI_JTAG_IDCODE 32'h10001602
 
 // Hardware Accelerator selection
 `define HWCRYPT


### PR DESCRIPTION
Part of the transition means we need to update the ID Code. Most likely this isn't the only place where we should update. Those things come to my mind:

- OpenOCD script (@gmartin102 are you using the one that is checked in here)
- Somewhere in the documentation. @jeremybennett where would you expect to find the expected ID Code in the documentation?