### PR TITLE
Update README.md to note links needed for Verilator models.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ If your changes introduce any Verilator errors, you either need to fix these, or
 
 This will create the Verilator library `Vcore_v_mcu_wrapper__ALL.a` in `build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator/obj_dir`.
 
+Note that when you use this library to build an application you will need to
+ensure that the directory `build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator/mem_init` is either symbolically linked or copied to the directory where the application will run. The model will load ROM images from this directory.
+
 ### Verilator lint check
 
 The system will run


### PR DESCRIPTION
Files changed:

	* README.md: Note that if using the Verilator model in an
	application there will be a need to link the mem_init directory
	from the build to the application's execution directory.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>