### PR TITLE
Add support for Vivado xsim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.bak
 *~
 *.bit
+*.swp
 install/
 build/
 buildsim.log

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ help:
 			@echo "nexys-emul:     generate bitstream for Nexys-A7-100T emulation)"
 			@echo "buildsim:       build for Questa sim"
 			@echo "sim:            run Questa sim"
-			@echo "clean:          remove generated files"
+			@echo "build-vivado:   build for Vivado simulation (xelab)"
+			@echo "sim-vivado:     run Vivado simulation (xsim)"
+			@echo "clean-vivado:   remove generated build files from Vivado build and/or sim"
+			@echo "all-vivado:     clean-, build-, sim-vivado (in that order)"
+			@echo "clean:          remove generated doc and sw files"
 
 all:	${IOSCRIPT_OUT} docs sw
 
@@ -42,6 +46,21 @@ src:	${IOSCRIPT_OUT}
 clean:
 	(cd docs; make clean)
 	(cd sw; make clean)
+
+all-vivado:	clean-vivado build-vivado sim-vivado
+
+clean-vivado:
+	rm -rf build
+	rm -rf xelab.* vivado-sim.log
+
+.PHONY: build-vivado
+build-vivado:
+	fusesoc --cores-root . run --target=sim --tool=xsim --setup \
+		--build openhwgroup.org:systems:core-v-mcu | tee vivado-sim.log
+
+.PHONY:sim-vivado
+sim-vivado:
+	(cd build/openhwgroup.org_systems_core-v-mcu_0/sim-xsim; make run) 2>&1 | tee sim.log
 
 .PHONY: model-lib
 model-lib:

--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -238,6 +238,16 @@ targets:
         - -suppress vlog-2583
         vsim_options:
         - -sv_lib ../../../tb/uartdpi/uartdpi -voptargs="-O1 +acc"
+      xsim:
+        xelab_options:
+        - --define XSIM
+        - --incr
+        - -dup_entity_as_module
+        - -relax
+        - --O0
+        - -v 0
+        - -timescale 1ns/1ps
+        xsim_options:
 
   # A target for a Verilator model as a library.  Note that we do not disable
   # UNOPTFLAT warnings, since these will affect performance, so we want to see

--- a/rtl/vendor/pulp_platform_axi/src/axi_burst_splitter.sv
+++ b/rtl/vendor/pulp_platform_axi/src/axi_burst_splitter.sv
@@ -317,7 +317,9 @@ module axi_burst_splitter #(
   // --------------------------------------------------
   `ifndef VERILATOR
   // pragma translate_off
+  `ifndef XSIM
   default disable iff (!rst_ni);
+  `endif
   // Inputs
   assume property (@(posedge clk_i) slv_req_i.aw_valid |->
       txn_supported(slv_req_i.aw.atop, slv_req_i.aw.burst, slv_req_i.aw.cache, slv_req_i.aw.len)
@@ -335,7 +337,7 @@ module axi_burst_splitter #(
   assert property (@(posedge clk_i) mst_req_o.ar_valid |-> mst_req_o.ar.len == '0)
     else $fatal(1, "AR burst longer than a single beat emitted!");
   // pragma translate_on
-  `endif
+  `endif // VERILATOR
 
 endmodule
 

--- a/rtl/vendor/pulp_platform_fpnew/src/fpnew_pkg.sv
+++ b/rtl/vendor/pulp_platform_fpnew/src/fpnew_pkg.sv
@@ -299,7 +299,11 @@ package fpnew_pkg;
   // -------------------------------------------
   // Returns the width of a FP format
   function automatic int unsigned fp_width(fp_format_e fmt);
+`ifdef XSIM
+    return 32; // FIXME: only valid for FP32
+`else
     return FP_ENCODINGS[fmt].exp_bits + FP_ENCODINGS[fmt].man_bits + 1;
+`endif
   endfunction
 
   // Returns the widest FP format present


### PR DESCRIPTION
Hi @gmartin102.  I added a couple of targets to the Makefile and a section to the fusesoc core file to support Xilinx Vivado simulation.  Also needed to add a couple of hacks to the RTL.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>