### PR TITLE
ci: Fix Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install requirements
       run: pip install -r python-requirements.txt
     - name: Install Verilator

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install requirements
       run: pip install -r python-requirements.txt
     - name: Install Verible
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install requirements
       run: pip install -r python-requirements.txt
     - name: Re-vendor and diff
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install requirements
       run: |
         pip install -r python-requirements.txt
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install requirements
       run: pip install -r python-requirements.txt
     # Check the proper formatting of all Bender.yml


### PR DESCRIPTION
That should fix the failing CI. The problem was an updated Python version, fixed that to `3.9` now.