### PR TITLE
Improve Verilator generated by make model-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ This will create the Verilator library `Vcore_v_mcu_wrapper__ALL.a` in `build/op
 Note that when you use this library to build an application you will need to
 ensure that the directory `build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator/mem_init` is either symbolically linked or copied to the directory where the application will run. The model will load ROM images from this directory.
 
+**Note.** The model is compiled at optimization level `-O3`, since performance is of importance with the likely applications, and with `-fPIC`, so it is suitable for inclusion in shared object libraries.
+
 ### Verilator lint check
 
 The system will run

--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -310,8 +310,9 @@ targets:
         mode: cc
         verilator_options:
         - -Wno-fatal
+        - -O3
         - --trace
-        - --CFLAGS -DVL_TIME_CONTEXT
+        - --CFLAGS -fPIC -DVL_TIME_CONTEXT
 
   lint:
     <<: *default_target


### PR DESCRIPTION
	The library version of the Verilator model is likely to be included
	in shared object libraries, so is compiled with -fPIC. The typical
	applications will be focussed on performance rather than debugging
	the Verilator model, so it is also compiled with -O3.

	* README.md: Extend documentation for the model-lib target.
	* core-v-mcu.core: Build verilator model for model-lib target with -O3 and -fPIC.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>