### PR TITLE
Fix up CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
         curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
         sudo apt update
-        sudo apt install verilator-4.100
+        sudo apt install verilator-5.008
     - name: Run Lint
       run: |
         ./util/verilog-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
         curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
         sudo apt update
-        sudo apt install verilator-5.008
+        sudo apt install verilator
     - name: Run Lint
       run: |
         ./util/verilog-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   format_verilog:
     name: Format Verilog Sources
     # This job runs on Linux (fixed ubuntu version)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,21 +63,22 @@ jobs:
   # Doc Up-to-Date #
   ##################
   # Check that the documentation is up-to-date.
-  doc-up-to-date:
-    name: Doc Up-to-Date
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install requirements
-      run: |
-        pip install -r python-requirements.txt
-        pip install -r docs/requirements.txt
-    - name: Generate doc and diff
-      run: |
-        make -C docs doc && util/git-diff.py --error-msg "::error ::Found differences, please re-generate the documentation."
+  # This check is depreciated as CORE-V-MCU no longer autogenerates its documentation.
+  #doc-up-to-date:
+  #  name: Doc Up-to-Date
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - uses: actions/setup-python@v2
+  #    with:
+  #      python-version: 3.9
+  #  - name: Install requirements
+  #    run: |
+  #      pip install -r python-requirements.txt
+  #      pip install -r docs/requirements.txt
+  #  - name: Generate doc and diff
+  #    run: |
+  #      make -C docs doc && util/git-diff.py --error-msg "::error ::Found differences, please re-generate the documentation."
 
   ####################
   # Format YML Files #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,18 +83,19 @@ jobs:
   ####################
   # Format YML Files #
   ####################
-  yamlfmt:
-    name: YAML Sources
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install requirements
-      run: pip install -r python-requirements.txt
-    # Check the proper formatting of all Bender.yml
-    - name: Check YAML formatting
-      run: |
-        util/yml-format
-        util/git-diff.py --error-msg "::error ::Found differences, run util/yml-format before committing."
+  # This check is no longer relavent as the connection to submdules was deliberately severed.
+  #yamlfmt:
+  #  name: YAML Sources
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - uses: actions/setup-python@v2
+  #    with:
+  #      python-version: 3.9
+  #  - name: Install requirements
+  #    run: pip install -r python-requirements.txt
+  #  # Check the proper formatting of all Bender.yml
+  #  - name: Check YAML formatting
+  #    run: |
+  #      util/yml-format
+  #      util/git-diff.py --error-msg "::error ::Found differences, run util/yml-format before committing."

--- a/core-v-mcu-emul.core
+++ b/core-v-mcu-emul.core
@@ -1,12 +1,6 @@
 CAPI=2:
-
-# Copyright 2021 OpenHW Group
-# Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
-# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-
 name: openhwgroup.org:systems:core-v-mcu-emul
 description: CORE-V MCU Emulation Top.
-
 filesets:
   emulation-rtl:
     depend:
@@ -23,28 +17,23 @@ filesets:
     - emulation/xilinx/rtl/pulp_clock_gating_xilinx.sv
     - emulation/xilinx/rtl/xilinx_core_v_mcu.v
     file_type: systemVerilogSource
-
   genesys2-xdc:
     files:
     - constraints/genesys2.xdc
     file_type: xdc
-
   genesys2-cfg:
     files:
     - fpga/genesys2.tcl
     file_type: tclSource
-
   nexys-xdc:
     files:
     - emulation/core-v-mcu-nexys/constraints/core-v-mcu-pin-assignment.xdc
     file_type: xdc
-
   nexys-cfg:
     files:
     - emulation/core-v-mcu-nexys/tcl/common.tcl
     - emulation/core-v-mcu-nexys/tcl/flatten.tcl
     file_type: tclSource
-
   xilinx-ips:
     files:
     - emulation/xilinx/ips/xilinx_clk_mngr.tcl
@@ -52,20 +41,17 @@ filesets:
     - emulation/xilinx/ips/xilinx_interleaved_ram.tcl
     - emulation/xilinx/ips/xilinx_private_ram.tcl
     file_type: tclSource
-
 parameters:
   PULP_FPGA_EMUL:
     datatype: bool
     paramtype: vlogdefine
     default: true
-
 targets:
   default: &default
     filesets:
     - emulation-rtl
     - xilinx-ips
     toplevel: xilinx_core_v_mcu
-
   genesys2:
     default_tool: vivado
     parameters: [PULP_FPGA_EMUL=true]
@@ -79,7 +65,6 @@ targets:
       vivado:
         part: xc7k325tffg900-2
     toplevel: xilinx_core_v_mcu
-
   nexys-a7-100t:
     <<: *default
     default_tool: vivado

--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -285,7 +285,6 @@ targets:
         - --O0
         - -v 0
         - -timescale 1ns/1ps
-        xsim_options:
 
   # A target for a Verilator model as a library.  Note that we do not disable
   # UNOPTFLAT warnings, since these will affect performance, so we want to see

--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -1,12 +1,6 @@
 CAPI=2:
-
-# Copyright 2021 OpenHW Group
-# Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
-# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-
 name: openhwgroup.org:systems:core-v-mcu
 description: CORE-V MCU Top.
-
 filesets:
   files_rtl_generic:
     depend:
@@ -82,12 +76,10 @@ filesets:
     - rtl/core-v-mcu/top/soc_domain.sv
     - rtl/core-v-mcu/top/core_v_mcu.sv
     file_type: systemVerilogSource
-
   rtl-behavioral:
     files:
     - rtl/core-v-mcu/components/freq_meter.sv
     file_type: systemVerilogSource
-
   rtl-simulation:
     files:
     - rtl/simulation/pPLL02F.sv
@@ -97,12 +89,10 @@ filesets:
     - rtl/simulation/top1_wrapper.sv
     - rtl/simulation/a2_bootrom.sv
     file_type: systemVerilogSource
-
   not_emulation-rtl:
     files:
     - rtl/core-v-mcu/soc/clk_gen.sv
     file_type: systemVerilogSource
-
   emulation-rtl:
     depend:
     - pulp-platform.org::tech_cells_xilinx
@@ -121,30 +111,24 @@ filesets:
     - rtl/simulation/top1_wrapper.sv
     - rtl/simulation/a2_bootrom.sv
     file_type: systemVerilogSource
-
   nexys-ips:
     files:
     - emulation/xilinx/ips/xilinx_clk_mngr.tcl
     file_type: tclSource
-
   genesys2-ips:
     files:
     - emulation/core-v-mcu-genesys2/ips/xilinx_clk_mngr.tcl
     file_type: tclSource
-
   xilinx-ips:
     files:
 #    - emulation/xilinx/ips/xilinx_slow_clk_mngr.tcl
     - emulation/xilinx/ips/xilinx_interleaved_ram.tcl
     - emulation/xilinx/ips/xilinx_private_ram.tcl
     file_type: tclSource
-
   rom_init:
     files:
     - tb/mem_init_files/boot.mem: {copyto: mem_init/boot.mem}
     file_type: mem
-
-
   mem_init_modelsim:
     files:
     - tb/mem_init_files/boot.mem: {copyto: mem_init/boot.mem}
@@ -156,7 +140,6 @@ filesets:
     - tb/mem_init_files/privateBank0.mem: {copyto: mem_init/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.bank_sram_pri0_i.u0.mem}
     - tb/mem_init_files/privateBank1.mem: {copyto: mem_init/core_v_mcu_tb.core_v_mcu_i.i_soc_domain.l2_ram_i.bank_sram_pri1_i.u0.mem}
     file_type: user
-
   mem_init_verilator:
     files:
     - tb/mem_init_files/verilatorBoot.mem: {copyto: mem_init/boot.mem}
@@ -168,55 +151,43 @@ filesets:
     - tb/mem_init_files/privateBank0.mem: {copyto: mem_init/TOP.core_v_mcu.i_soc_domain.l2_ram_i.bank_sram_pri0_i.u0.mem}
     - tb/mem_init_files/privateBank1.mem: {copyto: mem_init/TOP.core_v_mcu.i_soc_domain.l2_ram_i.bank_sram_pri1_i.u0.mem}
     file_type: user
-
-
   tb-rtl:
     files:
     - tb/core_v_mcu_tb.sv
     - tb/uartdpi/uartdpi.sv
     - tb/qspi_model/GD25Q128B.v
     file_type: systemVerilogSource
-
-
   nexys-rtl:
     files:
     - emulation/core-v-mcu-nexys/rtl/core_v_mcu_nexys.v
     - emulation/xilinx/rtl/fpga_clk_gen.sv
     file_type: systemVerilogSource
-
   nexys-xdc:
     files:
     - emulation/core-v-mcu-nexys/constraints/core-v-mcu-pin-assignment.xdc
     file_type: xdc
-
   xilinx-tcl:
     files:
     - emulation/xilinx/tcl/common.tcl
     - emulation/xilinx/tcl/flatten.tcl
     file_type: tclSource
-
   genesys2-rtl:
     files:
     - emulation/core-v-mcu-genesys2/rtl/core_v_mcu_genesys2.v
     - emulation/core-v-mcu-genesys2/rtl/fpga_clk_gen.sv
     file_type: systemVerilogSource
-
   genesys2-xdc:
     files:
     - emulation/core-v-mcu-genesys2/constraints/core-v-mcu-pin-assignment.xdc
     file_type: xdc
-
-  # Scripts for hooks
   pre_build_scripts:
     files:
     - rtl/core-v-mcu/scripts/vedit.sh
     file_type: user
-  # Waiver file, without which the model lib will not build.
   verilator-waiver:
     files:
     - rtl/core-v-mcu/verilator.waiver
     file_type: vlt
-
 parameters:
   PULP_FPGA_EMUL:
     datatype: bool
@@ -230,9 +201,6 @@ parameters:
     datatype: bool
     paramtype: vlogdefine
     default: true
-
-# A script to modify Verilator pre-build to generate a library, not an
-# executable.
 scripts:
   pre_build_scripts:
     cmd:
@@ -248,7 +216,6 @@ targets:
     - target_lint? (rtl-behavioral)
     - target_model-lib? (rtl-behavioral)
     toplevel: [core_v_mcu]
-
   sim:
     <<: *default_target
     default_tool: modelsim
@@ -325,6 +292,7 @@ targets:
         mode: lint-only
         verilator_options:
         - -Wno-fatal
+        - --timing
 
   nexys-a7-100t:
     <<: *default_target
@@ -344,7 +312,6 @@ targets:
       vivado:
         part: xc7a100tcsg324-1
     toplevel: core_v_mcu_nexys
-
   genesys2:
     <<: *default_target
     default_tool: vivado


### PR DESCRIPTION
This pull-request has several updates to address failing CI actions:

1. **ci / Verilator Lint**: needs Verilator-5.008 or newer to handle "pound delays" in the PLL models.  However, there currently is no simple `apt install install verilator` command that fetches and installs anything newer than v4.100.  Recommend we keep this action, and WAIVE it for now.
2. **lint / Format Verilog Sources**: the `runs-on` parameter was set to ubuntu 18.04 which GitHub no longer supports.  Passing now.
3. **lint / Vendor Up-to-Date**: passing.
4. **lint / Doc Up-to-Date**: depreciated as this repo no longer supports auto-generated documentation.
5. **lint / YamlFmt**: depreciated as this check is no longer required as the connection to sub-modules was deliberately severed.
6. `xsim_options` is no long recognised by fusesoc (was it ever?).