### PR TITLE
Makefile fixed for nexys emulation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ nexys-emul:
 					--pad-control rtl/core-v-mcu/top/pad_control.sv \
 					--emulation-toplevel core_v_mcu_nexys \
 					--input-xdc emulation/core-v-mcu-nexys/constraints/Nexys-A7-100T-Master.xdc \
-		                        --xilinx-core-v-mcu-sv emulation/core-v-mcu-nexys/rtl/core_v_mcu_util.v \
+					--xilinx-core-v-mcu-sv emulation/core-v-mcu-nexys/rtl/core_v_mcu_nexys.v \
 					--output-xdc emulation/core-v-mcu-nexys/constraints/core-v-mcu-pin-assignment.xdc
 				util/format-verible
 				@echo "*************************************"

--- a/rtl/core-v-mcu/components/apb_soc_ctrl.sv
+++ b/rtl/core-v-mcu/components/apb_soc_ctrl.sv
@@ -111,7 +111,8 @@ module apb_soc_ctrl #(
 
 
 );
-  localparam IDX_WIDTH = `LOG2(`N_IO);
+  localparam IDX_WIDTH =
+  `LOG2(`N_IO);
   localparam CONFIG = 12'h4??;
 
   logic [    IDX_WIDTH-1:0]                   r_io_pad;

--- a/rtl/core-v-mcu/soc/interleaved_crossbar.sv
+++ b/rtl/core-v-mcu/soc/interleaved_crossbar.sv
@@ -44,7 +44,9 @@ module interleaved_crossbar #(
   //Elaboration time asserations
   //Number of slaves must be power of two
   if ((NR_SLAVE_PORTS & (NR_SLAVE_PORTS - 1)) != 0) begin
-    $error("NR_SLAVE_PORTS must be power of two but was %d", NR_SLAVE_PORTS);
+    $error(
+        "NR_SLAVE_PORTS must be power of two but was %d", NR_SLAVE_PORTS
+    );
   end
 
   // Explode the input interface array to arrays of individual signals

--- a/rtl/core-v-mcu/top/pad_control.sv
+++ b/rtl/core-v-mcu/top/pad_control.sv
@@ -44,8 +44,10 @@ module pad_control (
   ///////////////////////////////////////////////////
   assign perio_in_o[0] = ((pad_mux_i[8] == 2'd0) ? io_in_i[8] : 1'b1);
   assign perio_in_o[1] = ((pad_mux_i[7] == 2'd0) ? io_in_i[7] : 1'b1);
-  assign perio_in_o[2] = ((pad_mux_i[9] == 2'd0) ? io_in_i[9] : 1'b1);
-  assign perio_in_o[3] = ((pad_mux_i[10] == 2'd0) ? io_in_i[10] : 1'b1);
+  assign perio_in_o[2] = ((pad_mux_i[9] == 2'd0) ? io_in_i[9] :
+                            ((pad_mux_i[11] == 2'd1) ? io_in_i[11] : 1'b1));
+  assign perio_in_o[3] = ((pad_mux_i[10] == 2'd0) ? io_in_i[10] :
+                            ((pad_mux_i[12] == 2'd1) ? io_in_i[12] : 1'b1));
   assign perio_in_o[4] = ((pad_mux_i[16] == 2'd0) ? io_in_i[16] : 1'b1);
   assign perio_in_o[5] = ((pad_mux_i[13] == 2'd0) ? io_in_i[13] : 1'b1);
   assign perio_in_o[6] = ((pad_mux_i[26] == 2'd1) ? io_in_i[26] : 1'b1);
@@ -55,15 +57,15 @@ module pad_control (
   assign perio_in_o[10] = ((pad_mux_i[15] == 2'd0) ? io_in_i[15] : 1'b1);
   assign perio_in_o[11] = ((pad_mux_i[19] == 2'd0) ? io_in_i[19] : 1'b1);
   assign perio_in_o[12] = ((pad_mux_i[20] == 2'd0) ? io_in_i[20] : 1'b1);
-  assign perio_in_o[13] = ((pad_mux_i[32] == 2'd1) ? io_in_i[32] : 1'b1);
-  assign perio_in_o[14] = ((pad_mux_i[29] == 2'd1) ? io_in_i[29] : 1'b1);
-  assign perio_in_o[15] = ((pad_mux_i[33] == 2'd1) ? io_in_i[33] : 1'b1);
-  assign perio_in_o[16] = ((pad_mux_i[34] == 2'd1) ? io_in_i[34] : 1'b1);
+  assign perio_in_o[13] = ((pad_mux_i[40] == 2'd1) ? io_in_i[40] : 1'b1);
+  assign perio_in_o[14] = ((pad_mux_i[38] == 2'd1) ? io_in_i[38] : 1'b1);
+  assign perio_in_o[15] = ((pad_mux_i[46] == 2'd1) ? io_in_i[46] : 1'b1);
+  assign perio_in_o[16] = ((pad_mux_i[47] == 2'd1) ? io_in_i[47] : 1'b1);
   assign perio_in_o[17] = 1'b1;
-  assign perio_in_o[18] = ((pad_mux_i[30] == 2'd1) ? io_in_i[30] : 1'b1);
-  assign perio_in_o[19] = ((pad_mux_i[31] == 2'd1) ? io_in_i[31] : 1'b1);
-  assign perio_in_o[20] = ((pad_mux_i[35] == 2'd1) ? io_in_i[35] : 1'b1);
-  assign perio_in_o[21] = ((pad_mux_i[36] == 2'd1) ? io_in_i[36] : 1'b1);
+  assign perio_in_o[18] = ((pad_mux_i[39] == 2'd1) ? io_in_i[39] : 1'b1);
+  assign perio_in_o[19] = ((pad_mux_i[41] == 2'd1) ? io_in_i[41] : 1'b1);
+  assign perio_in_o[20] = ((pad_mux_i[42] == 2'd1) ? io_in_i[42] : 1'b1);
+  assign perio_in_o[21] = ((pad_mux_i[37] == 2'd1) ? io_in_i[37] : 1'b1);
   assign perio_in_o[22] = ((pad_mux_i[23] == 2'd0) ? io_in_i[23] : 1'b1);
   assign perio_in_o[23] = ((pad_mux_i[24] == 2'd0) ? io_in_i[24] : 1'b1);
   assign perio_in_o[24] = ((pad_mux_i[46] == 2'd0) ? io_in_i[46] : 1'b1);
@@ -93,10 +95,12 @@ module pad_control (
   ///////////////////////////////////////////////////
   // Assign signals to the apbio bus
   ///////////////////////////////////////////////////
-  assign apbio_in_o[0] = ((pad_mux_i[43] == 2'd1) ? io_in_i[43] :
+  assign apbio_in_o[0] = ((pad_mux_i[12] == 2'd0) ? io_in_i[12] :
                            ((pad_mux_i[7] == 2'd2) ? io_in_i[7] : 1'b0));
-  assign apbio_in_o[1] = ((pad_mux_i[8] == 2'd2) ? io_in_i[8] : 1'b0);
-  assign apbio_in_o[2] = ((pad_mux_i[9] == 2'd2) ? io_in_i[9] : 1'b0);
+  assign apbio_in_o[1] = ((pad_mux_i[17] == 2'd0) ? io_in_i[17] :
+                           ((pad_mux_i[8] == 2'd2) ? io_in_i[8] : 1'b0));
+  assign apbio_in_o[2] = ((pad_mux_i[18] == 2'd0) ? io_in_i[18] :
+                           ((pad_mux_i[9] == 2'd2) ? io_in_i[9] : 1'b0));
   assign apbio_in_o[3] = ((pad_mux_i[10] == 2'd2) ? io_in_i[10] : 1'b0);
   assign apbio_in_o[4] = ((pad_mux_i[11] == 2'd2) ? io_in_i[11] : 1'b0);
   assign apbio_in_o[5] = ((pad_mux_i[12] == 2'd2) ? io_in_i[12] : 1'b0);
@@ -143,7 +147,7 @@ module pad_control (
   assign apbio_in_o[44] = ((pad_mux_i[41] == 2'd2) ? io_in_i[41] : 1'b0);
   assign apbio_in_o[45] = ((pad_mux_i[42] == 2'd2) ? io_in_i[42] : 1'b0);
   assign apbio_in_o[46] = ((pad_mux_i[43] == 2'd2) ? io_in_i[43] : 1'b0);
-  assign apbio_in_o[47] = ((pad_mux_i[11] == 2'd1) ? io_in_i[11] : 1'b0);
+  assign apbio_in_o[47] = ((pad_mux_i[45] == 2'd2) ? io_in_i[45] : 1'b0);
   assign apbio_in_o[48] = ((pad_mux_i[27] == 2'd0) ? io_in_i[27] : 1'b0);
   assign apbio_in_o[49] = ((pad_mux_i[28] == 2'd0) ? io_in_i[28] : 1'b0);
   assign apbio_in_o[50] = ((pad_mux_i[43] == 2'd0) ? io_in_i[43] : 1'b0);
@@ -221,10 +225,10 @@ module pad_control (
                          ((pad_mux_i[10] == 2'd2) ? apbio_out_i[3] :
                          ((pad_mux_i[10] == 2'd3) ? fpgaio_out_i[3] : 1'b0))));
   assign io_out_o[11] = ((pad_mux_i[11] == 2'd0) ? apbio_out_i[32] :
-                         ((pad_mux_i[11] == 2'd1) ? apbio_out_i[47] :
+                         ((pad_mux_i[11] == 2'd1) ? perio_out_i[`PERIO_UART1_TX] :
                          ((pad_mux_i[11] == 2'd2) ? apbio_out_i[4] :
                          ((pad_mux_i[11] == 2'd3) ? fpgaio_out_i[4] : 1'b0))));
-  assign io_out_o[12] = ((pad_mux_i[12] == 2'd0) ? 1'b0 :
+  assign io_out_o[12] = ((pad_mux_i[12] == 2'd0) ? apbio_out_i[0] :
                          ((pad_mux_i[12] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[12] == 2'd2) ? apbio_out_i[5] :
                          ((pad_mux_i[12] == 2'd3) ? fpgaio_out_i[5] : 1'b0))));
@@ -244,11 +248,11 @@ module pad_control (
                          ((pad_mux_i[16] == 2'd1) ? apbio_out_i[38] :
                          ((pad_mux_i[16] == 2'd2) ? apbio_out_i[9] :
                          ((pad_mux_i[16] == 2'd3) ? fpgaio_out_i[9] : 1'b0))));
-  assign io_out_o[17] = ((pad_mux_i[17] == 2'd0) ? 1'b1 :
+  assign io_out_o[17] = ((pad_mux_i[17] == 2'd0) ? apbio_out_i[1] :
                          ((pad_mux_i[17] == 2'd1) ? apbio_out_i[40] :
                          ((pad_mux_i[17] == 2'd2) ? apbio_out_i[10] :
                          ((pad_mux_i[17] == 2'd3) ? fpgaio_out_i[10] : 1'b0))));
-  assign io_out_o[18] = ((pad_mux_i[18] == 2'd0) ? 1'b1 :
+  assign io_out_o[18] = ((pad_mux_i[18] == 2'd0) ? apbio_out_i[2] :
                          ((pad_mux_i[18] == 2'd1) ? apbio_out_i[41] :
                          ((pad_mux_i[18] == 2'd2) ? apbio_out_i[11] :
                          ((pad_mux_i[18] == 2'd3) ? fpgaio_out_i[11] : 1'b0))));
@@ -293,63 +297,63 @@ module pad_control (
                          ((pad_mux_i[28] == 2'd2) ? apbio_out_i[21] :
                          ((pad_mux_i[28] == 2'd3) ? fpgaio_out_i[21] : 1'b0))));
   assign io_out_o[29] = ((pad_mux_i[29] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[29] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN0] :
+                         ((pad_mux_i[29] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[29] == 2'd2) ? apbio_out_i[22] :
                          ((pad_mux_i[29] == 2'd3) ? fpgaio_out_i[22] : 1'b0))));
   assign io_out_o[30] = ((pad_mux_i[30] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[30] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA0] :
+                         ((pad_mux_i[30] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[30] == 2'd2) ? apbio_out_i[23] :
                          ((pad_mux_i[30] == 2'd3) ? fpgaio_out_i[23] : 1'b0))));
   assign io_out_o[31] = ((pad_mux_i[31] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[31] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA1] :
+                         ((pad_mux_i[31] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[31] == 2'd2) ? apbio_out_i[24] :
                          ((pad_mux_i[31] == 2'd3) ? fpgaio_out_i[24] : 1'b0))));
   assign io_out_o[32] = ((pad_mux_i[32] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[32] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CLK] :
+                         ((pad_mux_i[32] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[32] == 2'd2) ? apbio_out_i[25] :
                          ((pad_mux_i[32] == 2'd3) ? fpgaio_out_i[25] : 1'b0))));
   assign io_out_o[33] = ((pad_mux_i[33] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[33] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN1] :
+                         ((pad_mux_i[33] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[33] == 2'd2) ? apbio_out_i[26] :
                          ((pad_mux_i[33] == 2'd3) ? fpgaio_out_i[26] : 1'b0))));
   assign io_out_o[34] = ((pad_mux_i[34] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[34] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN2] :
+                         ((pad_mux_i[34] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[34] == 2'd2) ? apbio_out_i[27] :
                          ((pad_mux_i[34] == 2'd3) ? fpgaio_out_i[27] : 1'b0))));
   assign io_out_o[35] = ((pad_mux_i[35] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[35] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA2] :
+                         ((pad_mux_i[35] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[35] == 2'd2) ? apbio_out_i[28] :
                          ((pad_mux_i[35] == 2'd3) ? fpgaio_out_i[28] : 1'b0))));
   assign io_out_o[36] = ((pad_mux_i[36] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[36] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA3] :
+                         ((pad_mux_i[36] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[36] == 2'd2) ? apbio_out_i[29] :
                          ((pad_mux_i[36] == 2'd3) ? fpgaio_out_i[29] : 1'b0))));
   assign io_out_o[37] = ((pad_mux_i[37] == 2'd0) ? perio_out_i[`PERIO_SDIO0_DATA3] :
-                         ((pad_mux_i[37] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[37] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA3] :
                          ((pad_mux_i[37] == 2'd2) ? apbio_out_i[30] :
                          ((pad_mux_i[37] == 2'd3) ? fpgaio_out_i[30] : 1'b0))));
   assign io_out_o[38] = ((pad_mux_i[38] == 2'd0) ? perio_out_i[`PERIO_SDIO0_CMD] :
-                         ((pad_mux_i[38] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[38] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN0] :
                          ((pad_mux_i[38] == 2'd2) ? apbio_out_i[31] :
                          ((pad_mux_i[38] == 2'd3) ? fpgaio_out_i[31] : 1'b0))));
   assign io_out_o[39] = ((pad_mux_i[39] == 2'd0) ? perio_out_i[`PERIO_SDIO0_DATA0] :
-                         ((pad_mux_i[39] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[39] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA0] :
                          ((pad_mux_i[39] == 2'd2) ? apbio_out_i[32] :
                          ((pad_mux_i[39] == 2'd3) ? fpgaio_out_i[32] : 1'b0))));
   assign io_out_o[40] = ((pad_mux_i[40] == 2'd0) ? perio_out_i[`PERIO_SDIO0_CLK] :
-                         ((pad_mux_i[40] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[40] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CLK] :
                          ((pad_mux_i[40] == 2'd2) ? apbio_out_i[43] :
                          ((pad_mux_i[40] == 2'd3) ? fpgaio_out_i[33] : 1'b0))));
   assign io_out_o[41] = ((pad_mux_i[41] == 2'd0) ? perio_out_i[`PERIO_SDIO0_DATA1] :
-                         ((pad_mux_i[41] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[41] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA1] :
                          ((pad_mux_i[41] == 2'd2) ? apbio_out_i[44] :
                          ((pad_mux_i[41] == 2'd3) ? fpgaio_out_i[34] : 1'b0))));
   assign io_out_o[42] = ((pad_mux_i[42] == 2'd0) ? perio_out_i[`PERIO_SDIO0_DATA2] :
-                         ((pad_mux_i[42] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[42] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_DATA2] :
                          ((pad_mux_i[42] == 2'd2) ? apbio_out_i[45] :
                          ((pad_mux_i[42] == 2'd3) ? fpgaio_out_i[35] : 1'b0))));
   assign io_out_o[43] = ((pad_mux_i[43] == 2'd0) ? apbio_out_i[50] :
-                         ((pad_mux_i[43] == 2'd1) ? apbio_out_i[0] :
+                         ((pad_mux_i[43] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[43] == 2'd2) ? apbio_out_i[46] :
                          ((pad_mux_i[43] == 2'd3) ? fpgaio_out_i[36] : 1'b0))));
   assign io_out_o[44] = ((pad_mux_i[44] == 2'd0) ? 1'b0 :
@@ -358,14 +362,14 @@ module pad_control (
                          ((pad_mux_i[44] == 2'd3) ? 1'b0 : 1'b0))));
   assign io_out_o[45] = ((pad_mux_i[45] == 2'd0) ? 1'b0 :
                          ((pad_mux_i[45] == 2'd1) ? 1'b0 :
-                         ((pad_mux_i[45] == 2'd2) ? 1'b0 :
+                         ((pad_mux_i[45] == 2'd2) ? apbio_out_i[47] :
                          ((pad_mux_i[45] == 2'd3) ? fpgaio_out_i[37] : 1'b0))));
   assign io_out_o[46] = ((pad_mux_i[46] == 2'd0) ? perio_out_i[`PERIO_I2CM1_SCL] :
-                         ((pad_mux_i[46] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[46] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN1] :
                          ((pad_mux_i[46] == 2'd2) ? 1'b0 :
                          ((pad_mux_i[46] == 2'd3) ? fpgaio_out_i[38] : 1'b0))));
   assign io_out_o[47] = ((pad_mux_i[47] == 2'd0) ? perio_out_i[`PERIO_I2CM1_SDA] :
-                         ((pad_mux_i[47] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[47] == 2'd1) ? perio_out_i[`PERIO_QSPIM1_CSN2] :
                          ((pad_mux_i[47] == 2'd2) ? 1'b0 :
                          ((pad_mux_i[47] == 2'd3) ? fpgaio_out_i[39] : 1'b0))));
 
@@ -396,10 +400,10 @@ module pad_control (
                          ((pad_mux_i[10] == 2'd2) ? apbio_oe_i[3] :
                          ((pad_mux_i[10] == 2'd3) ? fpgaio_oe_i[3] : 1'b0))));
   assign io_oe_o[11] = ((pad_mux_i[11] == 2'd0) ? apbio_oe_i[32] :
-                         ((pad_mux_i[11] == 2'd1) ? apbio_oe_i[47] :
+                         ((pad_mux_i[11] == 2'd1) ? 1'b1 :
                          ((pad_mux_i[11] == 2'd2) ? apbio_oe_i[4] :
                          ((pad_mux_i[11] == 2'd3) ? fpgaio_oe_i[4] : 1'b0))));
-  assign io_oe_o[12] = ((pad_mux_i[12] == 2'd0) ? 1'b1 :
+  assign io_oe_o[12] = ((pad_mux_i[12] == 2'd0) ? apbio_oe_i[0] :
                          ((pad_mux_i[12] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[12] == 2'd2) ? apbio_oe_i[5] :
                          ((pad_mux_i[12] == 2'd3) ? fpgaio_oe_i[5] : 1'b0))));
@@ -419,11 +423,11 @@ module pad_control (
                          ((pad_mux_i[16] == 2'd1) ? apbio_oe_i[38] :
                          ((pad_mux_i[16] == 2'd2) ? apbio_oe_i[9] :
                          ((pad_mux_i[16] == 2'd3) ? fpgaio_oe_i[9] : 1'b0))));
-  assign io_oe_o[17] = ((pad_mux_i[17] == 2'd0) ? 1'b1 :
+  assign io_oe_o[17] = ((pad_mux_i[17] == 2'd0) ? apbio_oe_i[1] :
                          ((pad_mux_i[17] == 2'd1) ? apbio_oe_i[40] :
                          ((pad_mux_i[17] == 2'd2) ? apbio_oe_i[10] :
                          ((pad_mux_i[17] == 2'd3) ? fpgaio_oe_i[10] : 1'b0))));
-  assign io_oe_o[18] = ((pad_mux_i[18] == 2'd0) ? 1'b1 :
+  assign io_oe_o[18] = ((pad_mux_i[18] == 2'd0) ? apbio_oe_i[2] :
                          ((pad_mux_i[18] == 2'd1) ? apbio_oe_i[41] :
                          ((pad_mux_i[18] == 2'd2) ? apbio_oe_i[11] :
                          ((pad_mux_i[18] == 2'd3) ? fpgaio_oe_i[11] : 1'b0))));
@@ -468,63 +472,63 @@ module pad_control (
                          ((pad_mux_i[28] == 2'd2) ? apbio_oe_i[21] :
                          ((pad_mux_i[28] == 2'd3) ? fpgaio_oe_i[21] : 1'b0))));
   assign io_oe_o[29] = ((pad_mux_i[29] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[29] == 2'd1) ? 1'b1 :
+                         ((pad_mux_i[29] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[29] == 2'd2) ? apbio_oe_i[22] :
                          ((pad_mux_i[29] == 2'd3) ? fpgaio_oe_i[22] : 1'b0))));
   assign io_oe_o[30] = ((pad_mux_i[30] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[30] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA0] :
+                         ((pad_mux_i[30] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[30] == 2'd2) ? apbio_oe_i[23] :
                          ((pad_mux_i[30] == 2'd3) ? fpgaio_oe_i[23] : 1'b0))));
   assign io_oe_o[31] = ((pad_mux_i[31] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[31] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA1] :
+                         ((pad_mux_i[31] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[31] == 2'd2) ? apbio_oe_i[24] :
                          ((pad_mux_i[31] == 2'd3) ? fpgaio_oe_i[24] : 1'b0))));
   assign io_oe_o[32] = ((pad_mux_i[32] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[32] == 2'd1) ? 1'b1 :
+                         ((pad_mux_i[32] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[32] == 2'd2) ? apbio_oe_i[25] :
                          ((pad_mux_i[32] == 2'd3) ? fpgaio_oe_i[25] : 1'b0))));
   assign io_oe_o[33] = ((pad_mux_i[33] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[33] == 2'd1) ? 1'b1 :
+                         ((pad_mux_i[33] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[33] == 2'd2) ? apbio_oe_i[26] :
                          ((pad_mux_i[33] == 2'd3) ? fpgaio_oe_i[26] : 1'b0))));
   assign io_oe_o[34] = ((pad_mux_i[34] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[34] == 2'd1) ? 1'b1 :
+                         ((pad_mux_i[34] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[34] == 2'd2) ? apbio_oe_i[27] :
                          ((pad_mux_i[34] == 2'd3) ? fpgaio_oe_i[27] : 1'b0))));
   assign io_oe_o[35] = ((pad_mux_i[35] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[35] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA2] :
+                         ((pad_mux_i[35] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[35] == 2'd2) ? apbio_oe_i[28] :
                          ((pad_mux_i[35] == 2'd3) ? fpgaio_oe_i[28] : 1'b0))));
   assign io_oe_o[36] = ((pad_mux_i[36] == 2'd0) ? 1'b0 :
-                         ((pad_mux_i[36] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA3] :
+                         ((pad_mux_i[36] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[36] == 2'd2) ? apbio_oe_i[29] :
                          ((pad_mux_i[36] == 2'd3) ? fpgaio_oe_i[29] : 1'b0))));
   assign io_oe_o[37] = ((pad_mux_i[37] == 2'd0) ? perio_oe_i[`PERIO_SDIO0_DATA3] :
-                         ((pad_mux_i[37] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[37] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA3] :
                          ((pad_mux_i[37] == 2'd2) ? apbio_oe_i[30] :
                          ((pad_mux_i[37] == 2'd3) ? fpgaio_oe_i[30] : 1'b0))));
   assign io_oe_o[38] = ((pad_mux_i[38] == 2'd0) ? perio_oe_i[`PERIO_SDIO0_CMD] :
-                         ((pad_mux_i[38] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[38] == 2'd1) ? 1'b1 :
                          ((pad_mux_i[38] == 2'd2) ? apbio_oe_i[31] :
                          ((pad_mux_i[38] == 2'd3) ? fpgaio_oe_i[31] : 1'b0))));
   assign io_oe_o[39] = ((pad_mux_i[39] == 2'd0) ? perio_oe_i[`PERIO_SDIO0_DATA0] :
-                         ((pad_mux_i[39] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[39] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA0] :
                          ((pad_mux_i[39] == 2'd2) ? apbio_oe_i[32] :
                          ((pad_mux_i[39] == 2'd3) ? fpgaio_oe_i[32] : 1'b0))));
   assign io_oe_o[40] = ((pad_mux_i[40] == 2'd0) ? 1'b1 :
-                         ((pad_mux_i[40] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[40] == 2'd1) ? 1'b1 :
                          ((pad_mux_i[40] == 2'd2) ? apbio_oe_i[43] :
                          ((pad_mux_i[40] == 2'd3) ? fpgaio_oe_i[33] : 1'b0))));
   assign io_oe_o[41] = ((pad_mux_i[41] == 2'd0) ? perio_oe_i[`PERIO_SDIO0_DATA1] :
-                         ((pad_mux_i[41] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[41] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA1] :
                          ((pad_mux_i[41] == 2'd2) ? apbio_oe_i[44] :
                          ((pad_mux_i[41] == 2'd3) ? fpgaio_oe_i[34] : 1'b0))));
   assign io_oe_o[42] = ((pad_mux_i[42] == 2'd0) ? perio_oe_i[`PERIO_SDIO0_DATA2] :
-                         ((pad_mux_i[42] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[42] == 2'd1) ? perio_oe_i[`PERIO_QSPIM1_DATA2] :
                          ((pad_mux_i[42] == 2'd2) ? apbio_oe_i[45] :
                          ((pad_mux_i[42] == 2'd3) ? fpgaio_oe_i[35] : 1'b0))));
   assign io_oe_o[43] = ((pad_mux_i[43] == 2'd0) ? apbio_oe_i[50] :
-                         ((pad_mux_i[43] == 2'd1) ? apbio_oe_i[0] :
+                         ((pad_mux_i[43] == 2'd1) ? 1'b0 :
                          ((pad_mux_i[43] == 2'd2) ? apbio_oe_i[46] :
                          ((pad_mux_i[43] == 2'd3) ? fpgaio_oe_i[36] : 1'b0))));
   assign io_oe_o[44] = ((pad_mux_i[44] == 2'd0) ? 1'b0 :
@@ -533,14 +537,14 @@ module pad_control (
                          ((pad_mux_i[44] == 2'd3) ? 1'b0 : 1'b0))));
   assign io_oe_o[45] = ((pad_mux_i[45] == 2'd0) ? 1'b0 :
                          ((pad_mux_i[45] == 2'd1) ? 1'b0 :
-                         ((pad_mux_i[45] == 2'd2) ? 1'b0 :
+                         ((pad_mux_i[45] == 2'd2) ? apbio_oe_i[47] :
                          ((pad_mux_i[45] == 2'd3) ? fpgaio_oe_i[37] : 1'b0))));
   assign io_oe_o[46] = ((pad_mux_i[46] == 2'd0) ? perio_oe_i[`PERIO_I2CM1_SCL] :
-                         ((pad_mux_i[46] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[46] == 2'd1) ? 1'b1 :
                          ((pad_mux_i[46] == 2'd2) ? 1'b0 :
                          ((pad_mux_i[46] == 2'd3) ? fpgaio_oe_i[38] : 1'b0))));
   assign io_oe_o[47] = ((pad_mux_i[47] == 2'd0) ? perio_oe_i[`PERIO_I2CM1_SDA] :
-                         ((pad_mux_i[47] == 2'd1) ? 1'b0 :
+                         ((pad_mux_i[47] == 2'd1) ? 1'b1 :
                          ((pad_mux_i[47] == 2'd2) ? 1'b0 :
                          ((pad_mux_i[47] == 2'd3) ? fpgaio_oe_i[39] : 1'b0))));
 endmodule

--- a/rtl/core-v-mcu/top/soc_domain.sv
+++ b/rtl/core-v-mcu/top/soc_domain.sv
@@ -156,7 +156,7 @@ module soc_domain
       dataaddr: dm::DataAddr
   };
 
-  dm::hartinfo_t [   NrHarts-1:0]       hartinfo;
+  dm::hartinfo_t [                 NrHarts-1:0      ] hartinfo;
 
   /*
        This module has been tested only with the default parameters.
@@ -166,49 +166,49 @@ module soc_domain
   //***************** SIGNALS DECLARATION ******************
   //********************************************************
 
-  logic                                 s_dmactive;
+  logic                                               s_dmactive;
 
-  logic                                 s_stoptimer;
-  logic                                 s_wd_expired;
-  logic          [           1:0]       s_fc_hwpe_events;
-  logic          [          31:0]       s_fc_events;
+  logic                                               s_stoptimer;
+  logic                                               s_wd_expired;
+  logic            [           1:0]                   s_fc_hwpe_events;
+  logic            [          31:0]                   s_fc_events;
 
-  logic          [           7:0]       s_soc_events_ack;
-  logic          [           7:0]       s_soc_events_val;
+  logic            [           7:0]                   s_soc_events_ack;
+  logic            [           7:0]                   s_soc_events_val;
 
-  logic                                 s_timer_lo_event;
-  logic                                 s_timer_hi_event;
+  logic                                               s_timer_lo_event;
+  logic                                               s_timer_hi_event;
 
-  logic          [EVNT_WIDTH-1:0]       s_cl_event_data;
-  logic                                 s_cl_event_valid;
-  logic                                 s_cl_event_ready;
+  logic            [EVNT_WIDTH-1:0]                   s_cl_event_data;
+  logic                                               s_cl_event_valid;
+  logic                                               s_cl_event_ready;
 
 
-  logic          [           7:0][31:0] s_apb_mpu_rules;
-  logic                                 s_supervisor_mode;
+  logic            [           7:0]           [31:0]  s_apb_mpu_rules;
+  logic                                               s_supervisor_mode;
 
-  logic          [          31:0]       s_fc_bootaddr;
+  logic            [          31:0]                   s_fc_bootaddr;
 
-  logic                                 s_periph_clk;
-  logic                                 s_periph_rst;
-  logic                                 s_soc_clk;
-  logic                                 s_soc_rstn;
-  logic                                 s_rstn_glob;
-  logic                                 s_sel_fll_clk;
+  logic                                               s_periph_clk;
+  logic                                               s_periph_rst;
+  logic                                               s_soc_clk;
+  logic                                               s_soc_rstn;
+  logic                                               s_rstn_glob;
+  logic                                               s_sel_fll_clk;
 
-  logic                                 s_dma_pe_evt;
-  logic                                 s_dma_pe_irq;
-  logic                                 s_pf_evt;
+  logic                                               s_dma_pe_evt;
+  logic                                               s_dma_pe_irq;
+  logic                                               s_pf_evt;
 
-  logic                                 s_fc_fetchen;
-  logic          [   NrHarts-1:0]       dm_debug_req;
+  logic                                               s_fc_fetchen;
+  logic            [   NrHarts-1:0]                   dm_debug_req;
 
-  logic                                 jtag_req_valid;
-  logic                                 debug_req_ready;
-  logic                                 jtag_resp_ready;
-  logic                                 jtag_resp_valid;
-  dm::dmi_req_t                         jtag_dmi_req;
-  dm::dmi_resp_t                        debug_resp;
+  logic                                               jtag_req_valid;
+  logic                                               debug_req_ready;
+  logic                                               jtag_resp_ready;
+  logic                                               jtag_resp_valid;
+  dm::dmi_req_t                                       jtag_dmi_req;
+  dm::dmi_resp_t                                      debug_resp;
   logic slave_grant, slave_valid, dm_slave_req, dm_slave_we;
   logic [31:0] dm_slave_addr, dm_slave_wdata, dm_slave_rdata;
   logic [ 3:0] dm_slave_be;

--- a/rtl/includes/pulp_peripheral_defines.svh
+++ b/rtl/includes/pulp_peripheral_defines.svh
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-`define BUILD_DATE 32'h20230710
-`define BUILD_TIME 32'h00144748
+`define BUILD_DATE 32'h20230919
+`define BUILD_TIME 32'h00111051
 
 //  PER_ID definitions
 `define PER_ID_UART      0
@@ -91,7 +91,7 @@
 `define IOINDEX_JTAG_TDO_O            2
 `define IOINDEX_JTAG_TMS_I            3
 `define IOINDEX_JTAG_TRST_I           4
-`define IOINDEX_SYSCLK_P_I            5
+`define IOINDEX_REF_CLK_I             5
 `define IOINDEX_RSTN_I                6
 `define IOINDEX_STM_I                 44
 `define IOINDEX_BOOTSEL_I             45


### PR DESCRIPTION
This fixes the name on the auto generated top level.  during testing I had changes the name to prevent overwriting of failed to return it to correct behavior.  My builds were passing due to a stale file with the correct name on the system.This addresses issue 323