### PR TITLE
Added new register access types in docs

### DIFF
--- a/docs/doc-src/mmap.rst
+++ b/docs/doc-src/mmap.rst
@@ -113,6 +113,10 @@ CSR Access Types:
 +-------------+---------------------------------------------------------------------+
 | RW0C        | Read & on Write bits with 0 get cleared, bits with 1 left unchanged |
 +-------------+---------------------------------------------------------------------+
+| RWC         | Read normal; Write Clears (value ignored; always writes a 0)        |
++-------------+---------------------------------------------------------------------+
+| RCW         | Read normal & clear after read; Write normal                        |
++-------------+---------------------------------------------------------------------+
 
 Implementation Details
 ----------------------


### PR DESCRIPTION
Added 2 new register access types:

- RWC: Read normal; Write Clears (value ignored; always writes a 0)
- RCW:  Read normal & clear after read; Write normal