### PR TITLE
rtl: Fix Verilator syntax error in PLL18_TOP.sv

### DIFF
--- a/rtl/simulation/PLL18_TOP.sv
+++ b/rtl/simulation/PLL18_TOP.sv
@@ -44,20 +44,14 @@ module PLL18_TOP (
    
 
    
-`ifdef VERILATOR
-   always_comb
-     if (RESETN == 0)
-       CLKO = 0l\;
-     else 
-       CLKO = FREF;
-`else
-   initial clk = 0;
-   initial forever #(1.25) clk = ~clk;
-   always_comb begin
-      CLKO = BYPASS ? FREF : clk;
-   end
-`endif
-   
-   
+initial begin
+   clk = 0;
+   forever #(1.25) clk = ~clk;
+end
+
+always_comb begin
+   CLKO = (BYPASS) ? FREF : clk;
+end
+
    
 endmodule  // PLL18_TOP


### PR DESCRIPTION
This PR resolves a syntax error in `rtl/simulation/PLL18_TOP.sv` (Issue #366). 